### PR TITLE
feat: add configuration loader and credential storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 log
 package-lock.json
+config.yaml
+data/credentials.json

--- a/config.js
+++ b/config.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+let config = {};
+
+function loadConfig(configPath) {
+  const filePath = configPath || path.join(__dirname, 'config.yaml');
+  try {
+    const fileContents = fs.readFileSync(filePath, 'utf8');
+    config = yaml.load(fileContents) || {};
+  } catch (err) {
+    console.error(`Failed to load config from ${filePath}:`, err);
+    config = {};
+  }
+  return config;
+}
+
+loadConfig();
+
+module.exports = {
+  get: () => config,
+  reload: loadConfig
+};

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,8 @@
+scanner:
+  services: []
+  allowDuplicates: true
+aiProvider:
+  name: openai
+  apiKey: YOUR_API_KEY
+userAuth:
+  credentialsPath: ./data/credentials.json

--- a/credentials.js
+++ b/credentials.js
@@ -1,0 +1,54 @@
+const fs = require('fs');
+const path = require('path');
+const bcrypt = require('bcrypt');
+const { get } = require('./config');
+
+const SALT_ROUNDS = 10;
+
+function getStorePath() {
+  const config = get() || {};
+  const relativePath = config.userAuth && config.userAuth.credentialsPath ? config.userAuth.credentialsPath : './data/credentials.json';
+  return path.isAbsolute(relativePath) ? relativePath : path.join(__dirname, relativePath);
+}
+
+function ensureDir(filePath) {
+  const dir = path.dirname(filePath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+function loadStore() {
+  const filePath = getStorePath();
+  try {
+    const data = fs.readFileSync(filePath, 'utf8');
+    return JSON.parse(data);
+  } catch (err) {
+    return {};
+  }
+}
+
+function saveStore(store) {
+  const filePath = getStorePath();
+  ensureDir(filePath);
+  fs.writeFileSync(filePath, JSON.stringify(store, null, 2));
+}
+
+function saveCredentials(username, password) {
+  const store = loadStore();
+  const hash = bcrypt.hashSync(password, SALT_ROUNDS);
+  store[username] = hash;
+  saveStore(store);
+}
+
+function verifyCredentials(username, password) {
+  const store = loadStore();
+  const hash = store[username];
+  if (!hash) return false;
+  return bcrypt.compareSync(password, hash);
+}
+
+module.exports = {
+  saveCredentials,
+  verifyCredentials
+};

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "winston": "^3.13.0",
-    "zlib": "^1.0.5"
+    "zlib": "^1.0.5",
+    "bcrypt": "^5.1.1",
+    "js-yaml": "^4.1.0"
   },
   "devDependencies": {
     "electron": "^31.7.7"

--- a/scanner.js
+++ b/scanner.js
@@ -1,12 +1,17 @@
 const noble = require('@abandonware/noble');
+const { get } = require('./config');
 
 console.log('Initializing Bluetooth scanner...');
+
+const scannerConfig = get().scanner || {};
 
 noble.on('stateChange', state => {
     console.log(`Bluetooth state changed to: ${state}`);
     if (state === 'poweredOn') {
         console.log('Starting Bluetooth scanning...');
-        noble.startScanning([], true); // Enable duplicates
+        const services = scannerConfig.services || [];
+        const allowDuplicates = scannerConfig.allowDuplicates !== undefined ? scannerConfig.allowDuplicates : true;
+        noble.startScanning(services, allowDuplicates);
     } else {
         console.log('Stopping Bluetooth scanning...');
         noble.stopScanning();


### PR DESCRIPTION
## Summary
- add YAML-based config loader and sample config
- support hashed credential storage configurable via YAML
- use config in scanner and update ignores

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689915423dbc832bbfcea8ce7599c668