### PR TITLE
Add discovery JSON logging and export utility

### DIFF
--- a/export-logs.js
+++ b/export-logs.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const path = require('path');
+
+async function exportLogs(outputPath) {
+    const dir = path.join(__dirname, 'data');
+    try {
+        const files = await fs.promises.readdir(dir);
+        const logs = [];
+        for (const file of files) {
+            if (file.endsWith('.json')) {
+                try {
+                    const content = await fs.promises.readFile(path.join(dir, file), 'utf8');
+                    logs.push(JSON.parse(content));
+                } catch (err) {
+                    console.error(`Skipping ${file}: ${err.message}`);
+                }
+            }
+        }
+        const output = JSON.stringify(logs, null, 2);
+        if (outputPath) {
+            await fs.promises.writeFile(outputPath, output);
+            console.log(`Exported ${logs.length} logs to ${outputPath}`);
+        } else {
+            console.log(output);
+        }
+    } catch (err) {
+        console.error(`Failed to export logs: ${err.message}`);
+        process.exit(1);
+    }
+}
+
+const outFile = process.argv[2];
+exportLogs(outFile);

--- a/scanner.js
+++ b/scanner.js
@@ -1,3 +1,5 @@
+const fs = require('fs');
+const path = require('path');
 const noble = require('@abandonware/noble');
 const { get } = require('./config');
 const { safeDb, knownRogueDb, flagAsPotential, flagAsRogue } = require('./src/db');
@@ -7,12 +9,29 @@ console.log('Initializing Bluetooth scanner...');
 
 const scannerConfig = get().scanner || {};
 
+async function logDiscovery(entry) {
+    const dir = path.join(__dirname, 'data');
+    try {
+        await fs.promises.mkdir(dir, { recursive: true });
+        const file = path.join(
+            dir,
+            `${new Date().toISOString().replace(/[:.]/g, '-')}.json`
+        );
+        await fs.promises.writeFile(file, JSON.stringify(entry, null, 2));
+    } catch (err) {
+        console.error(`Failed to write discovery log: ${err.message}`);
+    }
+}
+
 noble.on('stateChange', state => {
     console.log(`Bluetooth state changed to: ${state}`);
     if (state === 'poweredOn') {
         console.log('Starting Bluetooth scanning...');
         const services = scannerConfig.services || [];
-        const allowDuplicates = scannerConfig.allowDuplicates !== undefined ? scannerConfig.allowDuplicates : true;
+        const allowDuplicates =
+            scannerConfig.allowDuplicates !== undefined
+                ? scannerConfig.allowDuplicates
+                : true;
         noble.startScanning(services, allowDuplicates);
     } else {
         console.log('Stopping Bluetooth scanning...');
@@ -26,33 +45,67 @@ noble.on('discover', async peripheral => {
     const deviceRSSI = peripheral.rssi;
     const deviceUUIDs = peripheral.advertisement.serviceUuids.join(', ');
 
-    console.log(`Discovered device - Name: ${deviceName}, Address: ${deviceAddress}, RSSI: ${deviceRSSI}, UUIDs: ${deviceUUIDs}`);
+    console.log(
+        `Discovered device - Name: ${deviceName}, Address: ${deviceAddress}, RSSI: ${deviceRSSI}, UUIDs: ${deviceUUIDs}`
+    );
 
-    const record = { address: deviceAddress, name: deviceName, fingerprint: deviceUUIDs };
+    const dbRecord = {
+        address: deviceAddress,
+        name: deviceName,
+        fingerprint: deviceUUIDs
+    };
+
+    let classification = 'unknown';
 
     if (await safeDb.findByAddress(deviceAddress)) {
-        console.log(`Safe device detected: ${deviceName} (${deviceAddress})`);
-        return;
-    }
-
-    if (await knownRogueDb.findByAddress(deviceAddress)) {
-        console.warn(`Known rogue device detected: ${deviceName} (${deviceAddress})`);
-        return;
-    }
-
-    try {
-        const vulns = await checkDeviceVulnerabilities(deviceAddress);
-        if (vulns && vulns.length > 0) {
-            await flagAsRogue(record);
-            console.warn(`Confirmed rogue device added: ${deviceName} (${deviceAddress})`);
-            return;
+        classification = 'safe';
+    } else if (await knownRogueDb.findByAddress(deviceAddress)) {
+        classification = 'known_rogue';
+    } else {
+        try {
+            const vulns = await checkDeviceVulnerabilities(deviceAddress);
+            if (vulns && vulns.length > 0) {
+                classification = 'rogue';
+                await flagAsRogue(dbRecord);
+            } else {
+                classification = 'potential';
+                await flagAsPotential(dbRecord);
+            }
+        } catch (err) {
+            console.error(
+                `Vulnerability check failed for ${deviceAddress}: ${err.message}`
+            );
+            classification = 'potential';
+            await flagAsPotential(dbRecord);
         }
-    } catch (err) {
-        console.error(`Vulnerability check failed for ${deviceAddress}: ${err.message}`);
     }
 
-    await flagAsPotential(record);
-    console.log(`Unknown device flagged as potential rogue: ${deviceName} (${deviceAddress})`);
+    const logEntry = {
+        timestamp: new Date().toISOString(),
+        address: deviceAddress,
+        name: deviceName,
+        rssi: deviceRSSI,
+        uuids: peripheral.advertisement.serviceUuids,
+        classification
+    };
+
+    await logDiscovery(logEntry);
+
+    if (classification === 'safe') {
+        console.log(`Safe device detected: ${deviceName} (${deviceAddress})`);
+    } else if (classification === 'known_rogue') {
+        console.warn(
+            `Known rogue device detected: ${deviceName} (${deviceAddress})`
+        );
+    } else if (classification === 'rogue') {
+        console.warn(
+            `Confirmed rogue device added: ${deviceName} (${deviceAddress})`
+        );
+    } else if (classification === 'potential') {
+        console.log(
+            `Unknown device flagged as potential rogue: ${deviceName} (${deviceAddress})`
+        );
+    }
 });
 
 process.on('SIGINT', () => {


### PR DESCRIPTION
## Summary
- Log each Bluetooth discovery to a timestamped JSON file including metadata, signal strength, and classification
- Add `export-logs.js` CLI to bundle JSON discovery logs for cross‑app consumption

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6899195b9d04832b9568d5c4f85740d6