### PR TITLE
Add scheduled dataset updater for OUI and CVE feeds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ log/
 !known.rogue.devices.db
 !potential.rogue_devices.db
 
+# Downloaded vulnerability feeds
+data/*.json.gz
+
 # Configuration
 config.yaml
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Blabber Mouth BT Scanner is an Electron-based desktop application that scans for
 ## Features
 - Discover nearby Bluetooth devices and display name, address, RSSI and advertised UUIDs.
 - Parse a local [NVD](https://nvd.nist.gov/) feed to flag known vulnerable device identifiers.
+- Enrich device data with vendor information from the public IEEE OUI list (via [Wireshark's manuf](https://www.wireshark.org/download/automated/data/manuf)).
 - Structured logging to both the console and an `output.log` file.
 - Cross‑platform Electron UI with a React-based renderer.
 
@@ -25,6 +26,7 @@ The application will open a window and begin scanning for Bluetooth devices.  Pr
 - `npm run scan` – perform a headless Bluetooth scan and write the results to the JSON file defined in `config.yaml`.
 - `npm run clean` – remove logs, temporary databases and build artifacts using paths from `config.yaml`.
 - `npm test` – placeholder for future test coverage.
+- `npm run update-data` – fetch the [Wireshark manuf](https://www.wireshark.org/download/automated/data/manuf) (IEEE OUI) list and the NVD [CVE](https://nvd.nist.gov/) feed, merging fresh entries into flat files under `data/`.
 
 Paths for logs, databases and scan output can be adjusted in `config.yaml` under the `paths` section.
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "electron .",
     "clean": "node scripts/clean.js",
     "scan": "node scripts/scan.js",
-    "test": "echo \"No tests defined\""
+    "test": "echo \"No tests defined\"",
+    "update-data": "node scripts/update-datasets.js --once"
   },
   "keywords": [],
   "author": "",
@@ -18,15 +19,14 @@
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",
     "@mui/material": "^5.15.19",
-    "axios": "^1.7.2",
     "cli-table": "^0.3.11",
     "noble": "^1.9.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "winston": "^3.13.0",
-    "zlib": "^1.0.5",
     "bcrypt": "^5.1.1",
-    "js-yaml": "^4.1.0"
+    "js-yaml": "^4.1.0",
+    "node-cron": "^3.0.3"
   },
   "devDependencies": {
     "electron": "^31.7.7"

--- a/scripts/update-datasets.js
+++ b/scripts/update-datasets.js
@@ -1,0 +1,92 @@
+const fs = require('fs');
+const path = require('path');
+const { execFile } = require('child_process');
+const zlib = require('zlib');
+const cron = require('node-cron');
+
+const DATA_DIR = path.join(__dirname, '..', 'data');
+// Wireshark's "manuf" file mirrors the IEEE OUI list and is publicly available
+const OUI_URL = 'https://www.wireshark.org/download/automated/data/manuf';
+const CVE_URL = 'https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-recent.json.gz';
+const OUI_DB = path.join(DATA_DIR, 'oui.db');
+const CVE_DB = path.join(DATA_DIR, 'cve.db');
+const CVE_GZ = path.join(DATA_DIR, 'nvdcve-recent.json.gz');
+
+function fetch(url, binary = false) {
+    return new Promise((resolve, reject) => {
+        const args = ['-L', url];
+        const options = { maxBuffer: 1024 * 1024 * 50, encoding: binary ? 'binary' : 'utf8' };
+        execFile('curl', args, options, (err, stdout) => {
+            if (err) return reject(err);
+            resolve(binary ? Buffer.from(stdout, 'binary') : stdout);
+        });
+    });
+}
+
+async function mergeDb(file, items, key) {
+    await fs.promises.mkdir(path.dirname(file), { recursive: true });
+    const existing = new Set();
+    if (fs.existsSync(file)) {
+        const lines = await fs.promises.readFile(file, 'utf8');
+        lines.split('\n').filter(Boolean).forEach(line => {
+            try {
+                const obj = JSON.parse(line);
+                existing.add(obj[key]);
+            } catch (err) {
+                // ignore malformed lines
+            }
+        });
+    }
+    const toAppend = items
+        .filter(item => !existing.has(item[key]))
+        .map(item => JSON.stringify(item) + '\n');
+    if (toAppend.length) {
+        await fs.promises.appendFile(file, toAppend.join(''), 'utf8');
+    }
+    return toAppend.length;
+}
+
+async function updateOUI() {
+    const data = await fetch(OUI_URL);
+    const items = [];
+    data.split('\n').forEach(line => {
+        if (!line || line.startsWith('#')) return;
+        const match = line.match(/^([0-9A-Fa-f:-]+)\s+\S+\s+(.+)$/);
+        if (match) {
+            items.push({ oui: match[1], organization: match[2].trim() });
+        }
+    });
+    const added = await mergeDb(OUI_DB, items, 'oui');
+    console.log(`OUI database updated, ${added} new entries`);
+}
+
+async function updateCVE() {
+    const buffer = await fetch(CVE_URL, true);
+    await fs.promises.mkdir(DATA_DIR, { recursive: true });
+    await fs.promises.writeFile(CVE_GZ, buffer);
+    const json = JSON.parse(zlib.gunzipSync(buffer).toString());
+    const items = json.CVE_Items.map(item => ({
+        id: item.cve.CVE_data_meta.ID,
+        description: item.cve.description.description_data.map(d => d.value).join(' ')
+    }));
+    const added = await mergeDb(CVE_DB, items, 'id');
+    console.log(`CVE database updated, ${added} new entries`);
+}
+
+async function updateAll() {
+    await updateOUI();
+    await updateCVE();
+}
+
+async function main() {
+    await updateAll();
+    if (process.argv.includes('--once')) return;
+    cron.schedule('0 2 * * *', updateAll);
+}
+
+if (require.main === module) {
+    main().catch(err => {
+        console.error('Update failed:', err.message);
+        process.exit(1);
+    });
+}

--- a/vulnerability-checker.js
+++ b/vulnerability-checker.js
@@ -3,7 +3,8 @@ const path = require('path');
 const zlib = require('zlib');
 
 // Path to the downloaded JSON feed
-const JSON_FEED_PATH = path.join(__dirname, 'nvdcve-1.1-2024.json.gz');
+// Updated by scripts/update-datasets.js
+const JSON_FEED_PATH = path.join(__dirname, 'data', 'nvdcve-recent.json.gz');
 
 // Function to unzip and parse the JSON feed
 async function parseVulnerabilityFeed() {


### PR DESCRIPTION
## Summary
- document OUI and CVE data sources and expose `npm run update-data`
- track downloaded CVE feed and expose path to vulnerability checker
- add cron-based script that fetches Wireshark's `manuf` (IEEE OUI) list and NVD CVE JSON feed, merging them into local DBs

## Testing
- `npm test`
- `node scripts/update-datasets.js --once`

------
https://chatgpt.com/codex/tasks/task_e_689920111e58832b9f186b088d8dadcd