### PR TITLE
Add rootkit detection and file integrity monitoring

### DIFF
--- a/file-integrity.js
+++ b/file-integrity.js
@@ -1,0 +1,62 @@
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const logger = require('./logger');
+
+const baselineFile = path.join(__dirname, 'data', 'file-baseline.json');
+
+function getAllFiles(dir, fileList = []) {
+    const entries = fs.readdirSync(dir);
+    entries.forEach(entry => {
+        if (['node_modules', '.git', 'data', 'log'].includes(entry)) {
+            return;
+        }
+        const fullPath = path.join(dir, entry);
+        const stat = fs.statSync(fullPath);
+        if (stat.isDirectory()) {
+            getAllFiles(fullPath, fileList);
+        } else {
+            fileList.push(fullPath);
+        }
+    });
+    return fileList;
+}
+
+function hashFile(filePath) {
+    const fileBuffer = fs.readFileSync(filePath);
+    return crypto.createHash('sha256').update(fileBuffer).digest('hex');
+}
+
+function createBaseline(targetDir) {
+    const files = getAllFiles(targetDir);
+    const hashes = {};
+    files.forEach(file => {
+        hashes[path.relative(targetDir, file)] = hashFile(file);
+    });
+    fs.writeFileSync(baselineFile, JSON.stringify({ targetDir, hashes }, null, 2));
+    logger.info(`File baseline created for ${targetDir}`);
+    return hashes;
+}
+
+function checkIntegrity(targetDir) {
+    if (!fs.existsSync(baselineFile)) {
+        logger.warn('Baseline file missing, integrity check skipped');
+        return { status: 'missing-baseline', changed: [] };
+    }
+    const baseline = JSON.parse(fs.readFileSync(baselineFile));
+    const files = getAllFiles(targetDir);
+    const current = {};
+    files.forEach(file => {
+        current[path.relative(targetDir, file)] = hashFile(file);
+    });
+    const changed = [];
+    Object.keys(baseline.hashes).forEach(file => {
+        if (current[file] !== baseline.hashes[file]) {
+            changed.push(file);
+        }
+    });
+    logger.info(`Integrity check complete: ${changed.length} files changed`);
+    return { status: 'ok', changed };
+}
+
+module.exports = { createBaseline, checkIntegrity, baselineFile };

--- a/index.html
+++ b/index.html
@@ -17,6 +17,10 @@
         <button id="scan-vulnerabilities">Scan for Vulnerabilities</button>
     </div>
 </div>
+<h2>Security Checks</h2>
+<button id="run-security-checks">Run Security Checks</button>
+<div id="rootkit-result"></div>
+<div id="integrity-result"></div>
 <script src="renderer.js"></script>
 </body>
 </html>

--- a/renderer.js
+++ b/renderer.js
@@ -123,3 +123,17 @@ ${vulnerabilityInfo});
         alert(Error scanning vulnerabilities: ${error.message}`);
     }
 };
+
+const securityButton = document.getElementById('run-security-checks');
+const rootkitResult = document.getElementById('rootkit-result');
+const integrityResult = document.getElementById('integrity-result');
+
+securityButton.onclick = async () => {
+    const result = await electron.ipcRenderer.invoke('run-security-checks');
+    rootkitResult.innerText = result.rootkit.status === 'ok'
+        ? 'Rootkit check passed'
+        : result.rootkit.output;
+    integrityResult.innerText = (result.integrity.changed && result.integrity.changed.length === 0)
+        ? 'No file changes detected'
+        : `Changed files: ${result.integrity.changed.join(', ')}`;
+};

--- a/rootkit-checker.js
+++ b/rootkit-checker.js
@@ -1,0 +1,19 @@
+const { exec } = require('child_process');
+const logger = require('./logger');
+
+function runRootkitCheck() {
+    return new Promise(resolve => {
+        exec('chkrootkit', (error, stdout, stderr) => {
+            if (error) {
+                logger.error(`Rootkit check failed: ${error.message}`);
+                resolve({ status: 'error', output: stderr || error.message });
+                return;
+            }
+            logger.info('Rootkit check completed');
+            logger.info(stdout.trim());
+            resolve({ status: 'ok', output: stdout });
+        });
+    });
+}
+
+module.exports = { runRootkitCheck };


### PR DESCRIPTION
## Summary
- Add chkrootkit-based rootkit scan module
- Implement filesystem baseline hashing and integrity checks
- Surface security check results in the Electron dashboard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689922d2e910832b8a69f706e9df6259