### PR TITLE
feat: add AI helper and Ollama config

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,5 +30,28 @@ The application will open a window and begin scanning for Bluetooth devices.  Pr
 
 Paths for logs, databases and scan output can be adjusted in `config.yaml` under the `paths` section.
 
+## AI Summaries (Optional)
+
+Scan results can optionally be sent to an AI model for summarization or
+anomaly analysis. The feature is opt-in and remains inactive until a
+supported provider is configured in `config.yaml`.
+
+```yaml
+aiProvider:
+  name: ollama        # or 'openai'
+  model: llama3       # model name for the provider
+  endpoint: http://localhost:11434/api/generate  # Ollama example
+  apiKey: YOUR_API_KEY # required for OpenAI
+```
+
+With a provider configured you can send data using the helper module:
+
+```javascript
+const { sendScanSummary, sendAnomaly } = require('./ai-helper');
+await sendScanSummary('5 devices detected with no vulnerabilities.');
+```
+
+To opt out, remove the `aiProvider` block or leave `name` empty.
+
 ## Contributing
 Contributions are welcome!  Please follow the guidelines in `CHANGELOG.md` and use pull requests for all changes.

--- a/ai-helper.js
+++ b/ai-helper.js
@@ -1,0 +1,60 @@
+const { get } = require('./config');
+
+async function sendMessage(message) {
+    const cfg = get().aiProvider || {};
+    if (!cfg.name) {
+        console.warn('AI provider not configured.');
+        return null;
+    }
+
+    if (cfg.name === 'ollama') {
+        const endpoint = cfg.endpoint || 'http://localhost:11434/api/generate';
+        const model = cfg.model || 'llama3';
+        const res = await fetch(endpoint, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ model, prompt: message })
+        });
+        if (!res.ok) {
+            throw new Error(`Ollama request failed: ${res.status}`);
+        }
+        return res.json();
+    }
+
+    if (cfg.name === 'openai') {
+        const endpoint = cfg.endpoint || 'https://api.openai.com/v1/chat/completions';
+        const apiKey = cfg.apiKey;
+        if (!apiKey) {
+            throw new Error('OpenAI API key missing in config');
+        }
+        const model = cfg.model || 'gpt-4o-mini';
+        const res = await fetch(endpoint, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${apiKey}`
+            },
+            body: JSON.stringify({
+                model,
+                messages: [{ role: 'user', content: message }]
+            })
+        });
+        if (!res.ok) {
+            throw new Error(`OpenAI request failed: ${res.status}`);
+        }
+        return res.json();
+    }
+
+    console.warn(`Unsupported AI provider: ${cfg.name}`);
+    return null;
+}
+
+async function sendScanSummary(summary) {
+    return sendMessage(`Scan summary:\n${summary}`);
+}
+
+async function sendAnomaly(details) {
+    return sendMessage(`Anomaly detected:\n${details}`);
+}
+
+module.exports = { sendScanSummary, sendAnomaly };

--- a/config.yaml
+++ b/config.yaml
@@ -2,8 +2,10 @@ scanner:
   services: []
   allowDuplicates: true
 aiProvider:
-  name: openai
-  apiKey: YOUR_API_KEY
+  name: openai # or 'ollama'
+  apiKey: YOUR_API_KEY # required for OpenAI
+  endpoint: http://localhost:11434/api/generate # default Ollama endpoint
+  model: gpt-4o-mini
 userAuth:
   credentialsPath: ./data/credentials.json
 paths:


### PR DESCRIPTION
## Summary
- extend config.yaml with provider endpoint and model for Ollama support
- add helper to send scan summaries or anomalies to OpenAI or Ollama
- document optional AI integration and opt-in controls in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68992be3d320832bbcefb529f1e9514d