### PR TITLE
feat: add credential setup script and first-run check

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,7 +12,12 @@ These instructions describe how to set up Blabber Mouth BT Scanner on common pla
    ```bash
    npm install
    ```
-4. Launch the application:
+4. Initialize the credential store:
+   ```bash
+   node scripts/add-user.js
+   ```
+   This creates `data/credentials.json` (ignored by Git). Keep this file out of version control.
+5. Launch the application:
    ```bash
    npm start
    ```
@@ -24,18 +29,34 @@ These instructions describe how to set up Blabber Mouth BT Scanner on common pla
    sudo apt-get install -y bluetooth bluez libbluetooth-dev libudev-dev
    ```
 2. Install Node.js from your package manager or from NodeSource.
-3. Install dependencies and run:
+3. Install project dependencies:
    ```bash
    npm install
+   ```
+4. Initialize the credential store:
+   ```bash
+   node scripts/add-user.js
+   ```
+   This creates `data/credentials.json` (ignored by Git). Keep this file out of version control.
+5. Launch the application:
+   ```bash
    npm start
    ```
 
 ## Windows
 1. Install [Node.js](https://nodejs.org/) and ensure `node` and `npm` are in your `PATH`.
 2. Install [Visual Studio Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) for native module compilation.
-3. From the project directory run:
+3. From the project directory install dependencies:
    ```bash
    npm install
+   ```
+4. Initialize the credential store:
+   ```bash
+   node scripts/add-user.js
+   ```
+   This creates `data/credentials.json` (ignored by Git). Keep this file out of version control.
+5. Launch the application:
+   ```bash
    npm start
    ```
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ Blabber Mouth BT Scanner is an Electron-based desktop application that scans for
 ## Getting Started
 See [INSTALL.md](INSTALL.md) for platform prerequisites, dependency installation and launch instructions.  The project uses semantic versioning; release history and guidelines live in [CHANGELOG.md](CHANGELOG.md).
 
+Before launching the application for the first time, initialize the credential store:
+
+```bash
+node scripts/add-user.js
+```
+
+This creates `data/credentials.json` with a hashed username/password pair.  The file is ignored by Git; keep it out of version control.
+
 ## Usage
 Once dependencies are installed you can start the app with:
 

--- a/renderer.js
+++ b/renderer.js
@@ -29,6 +29,16 @@ const noble = (window.electron && window.electron.noble) || require('@abandonwar
 const { ipcRenderer } = (window.electron) || require('electron');
 const { checkDeviceVulnerabilities } = require('./vulnerability-checker');
 const session = require('./session');
+const fs = require('fs');
+const path = require('path');
+const { get: getConfig } = require('./config');
+
+function credentialStoreExists() {
+  const config = getConfig() || {};
+  const rel = config.userAuth && config.userAuth.credentialsPath ? config.userAuth.credentialsPath : './data/credentials.json';
+  const filePath = path.isAbsolute(rel) ? rel : path.join(__dirname, rel);
+  return fs.existsSync(filePath);
+}
 
 function BluetoothIcon(props) {
   return (
@@ -224,6 +234,13 @@ function Root() {
     }, 1000);
     return () => clearInterval(interval);
   }, [token]);
+
+  if (!credentialStoreExists()) {
+    return React.createElement(Container, { maxWidth: 'sm', sx: { mt: 8 } },
+      React.createElement(Typography, { variant: 'h6', sx: { mb: 2 } }, 'Credential store not found'),
+      React.createElement(Typography, null, 'Run "node scripts/add-user.js" to create one.')
+    );
+  }
 
   if (!token) {
     return React.createElement(Login, { onSuccess: setToken });

--- a/scripts/add-user.js
+++ b/scripts/add-user.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+const readline = require('readline');
+const { saveCredentials } = require('../credentials');
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout
+});
+
+rl.question('Username: ', username => {
+  rl.question('Password: ', password => {
+    saveCredentials(username, password);
+    console.log('Credentials saved.');
+    rl.close();
+  });
+});


### PR DESCRIPTION
## Summary
- add CLI script to create hashed credentials in data/credentials.json
- document credential initialization in README and INSTALL
- show message in UI when credential store is missing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689950a07408832b877665fd3ae352cd