### PR TITLE
Add unit tests and Jest setup

### DIFF
--- a/__tests__/config.test.js
+++ b/__tests__/config.test.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const config = require('../config');
+
+describe('config module', () => {
+  const defaultPath = path.join(__dirname, '..', 'config.yaml');
+
+  afterEach(() => {
+    config.reload(defaultPath);
+  });
+
+  test('loads default configuration', () => {
+    const cfg = config.get();
+    expect(cfg).toHaveProperty('scanner');
+  });
+
+  test('reloads from a given path', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cfg-'));
+    const tempPath = path.join(tempDir, 'config.yaml');
+    fs.writeFileSync(tempPath, 'foo: bar\n');
+
+    config.reload(tempPath);
+    expect(config.get()).toEqual({ foo: 'bar' });
+
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test('returns empty object when file missing', () => {
+    config.reload('/non/existent/path.yaml');
+    expect(config.get()).toEqual({});
+  });
+});

--- a/__tests__/credentials.test.js
+++ b/__tests__/credentials.test.js
@@ -1,0 +1,49 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const config = require('../config');
+
+jest.mock('bcrypt', () => ({
+  hashSync: pw => `hashed-${pw}`,
+  compareSync: (pw, hash) => hash === `hashed-${pw}`
+}));
+
+const { saveCredentials, verifyCredentials } = require('../credentials');
+
+describe('credentials module', () => {
+  const defaultPath = path.join(__dirname, '..', 'config.yaml');
+
+  afterEach(() => {
+    config.reload(defaultPath);
+  });
+
+  test('saves and verifies credentials', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cred-'));
+    const credPath = path.join(tempDir, 'creds.json');
+    const yamlPath = path.join(tempDir, 'config.yaml');
+    fs.writeFileSync(yamlPath, `userAuth:\n  credentialsPath: ${credPath}\n`);
+    config.reload(yamlPath);
+
+    saveCredentials('alice', 'secret');
+    expect(verifyCredentials('alice', 'secret')).toBe(true);
+    expect(verifyCredentials('alice', 'wrong')).toBe(false);
+
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test('seeds default credentials when empty', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'seed-'));
+    const credPath = path.join(tempDir, 'creds.json');
+    const yamlPath = path.join(tempDir, 'config.yaml');
+    fs.writeFileSync(
+      yamlPath,
+      `userAuth:\n  credentialsPath: ${credPath}\n  defaultUser: admin\n  defaultPassword: pass\n`
+    );
+    config.reload(yamlPath);
+
+    expect(verifyCredentials('admin', 'pass')).toBe(true);
+    expect(fs.existsSync(credPath)).toBe(true);
+
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+});

--- a/__tests__/db.test.js
+++ b/__tests__/db.test.js
@@ -1,0 +1,58 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { DeviceDb } = require('../src/db/deviceDb');
+
+let mockConfig = {};
+jest.mock('../config', () => ({ get: () => mockConfig }));
+
+describe('DeviceDb', () => {
+  test('appends and retrieves entries', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'devdb-'));
+    const dbPath = path.join(tempDir, 'db.json');
+    const db = new DeviceDb(dbPath);
+
+    expect(await db.loadAll()).toEqual([]);
+
+    const entry = { address: 'AA', fingerprint: 'FP' };
+    await db.append(entry);
+
+    expect(await db.loadAll()).toEqual([entry]);
+    expect(await db.findByAddress('AA')).toEqual(entry);
+    expect(await db.findByFingerprint('FP')).toEqual(entry);
+
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+});
+
+describe('db index', () => {
+  afterEach(() => {
+    delete require.cache[require.resolve('../src/db')];
+  });
+
+  test('flags potential and rogue devices', async () => {
+    const tempDir = fs.mkdtempSync(path.join(process.cwd(), 'dbindex-'));
+    const safePath = path.join(tempDir, 'safe.db');
+    const potPath = path.join(tempDir, 'potential.db');
+    const roguePath = path.join(tempDir, 'rogue.db');
+
+    mockConfig = {
+      paths: {
+        safeDb: path.relative(process.cwd(), safePath),
+        potentialDb: path.relative(process.cwd(), potPath),
+        rogueDb: path.relative(process.cwd(), roguePath)
+      }
+    };
+    const db = require('../src/db');
+    const device = { address: '00', fingerprint: 'fp' };
+    await db.flagAsPotential(device);
+    await db.flagAsRogue(device);
+
+    const potContent = fs.readFileSync(potPath, 'utf8').trim();
+    const rogueContent = fs.readFileSync(roguePath, 'utf8').trim();
+    expect(potContent).toBe(JSON.stringify(device));
+    expect(rogueContent).toBe(JSON.stringify(device));
+
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "electron .",
     "clean": "node scripts/clean.js",
     "scan": "node scripts/scan.js",
-    "test": "echo \"No tests defined\"",
+    "test": "jest",
     "update-data": "node scripts/update-datasets.js --once"
   },
   "keywords": [],
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "electron": "^31.7.7",
-    "eslint": "^9.33.0"
+    "eslint": "^9.33.0",
+    "jest": "^29.7.0"
   }
 }


### PR DESCRIPTION
## Summary
- add Jest as a dev dependency and configure `npm test` to run it
- create unit tests for config reload behavior, credential storage, and device databases

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689960476054832bb133fbd8fa8212d9